### PR TITLE
Adds thread_broadcast subtype and decodes the "hidden" property

### DIFF
--- a/Sources/Models/Message+Subtype.swift
+++ b/Sources/Models/Message+Subtype.swift
@@ -1,6 +1,6 @@
 
 public extension Message {
-    public enum Subtype: String {
+    enum Subtype: String {
         case bot_message
 
         case channel_archive
@@ -32,6 +32,8 @@ public extension Message {
         case pinned_item
         case unpinned_item
 
+        @available(*, deprecated)
         case reply_broadcast
+        case thread_broadcast
     }
 }

--- a/Sources/Models/Message+Subtype.swift
+++ b/Sources/Models/Message+Subtype.swift
@@ -1,6 +1,6 @@
 
-public extension Message {
-    enum Subtype: String {
+extension Message {
+    public enum Subtype: String {
         case bot_message
 
         case channel_archive

--- a/Sources/Models/Message+Subtype.swift
+++ b/Sources/Models/Message+Subtype.swift
@@ -32,7 +32,7 @@ public extension Message {
         case pinned_item
         case unpinned_item
 
-        @available(*, deprecated)
+        @available(*, deprecated, message: "Use thread_broadcast instead")
         case reply_broadcast
         case thread_broadcast
     }

--- a/Sources/Models/Message.swift
+++ b/Sources/Models/Message.swift
@@ -13,6 +13,7 @@ public struct Message {
     public let thread: Thread?
     public let group: ModelPointer<Group>?
     public let bot_id: ModelPointer<BotUser>?
+    public let hidden: Bool
 }
 
 extension Message: Common.Decodable {
@@ -29,7 +30,8 @@ extension Message: Common.Decodable {
                 im: imPointer(from: decoder),
                 thread: try messageThread(from: decoder),
                 group: groupPointer(from: decoder),
-                bot_id: try? decoder.pointer(at: ["bot_id"])
+                bot_id: try? decoder.pointer(at: ["bot_id"]),
+                hidden: (try? decoder.value(at: ["hidden"])) ?? false
             )
         }
     }


### PR DESCRIPTION
For messages that are sent to a thread with "Also send to # channel name" checked, Slack's API now uses "thread_broadcast" as the subtype. By adding that to the enum, it'll get picked up correctly now.

The RTM api receives 2 events for each broadcast message. One for the thread, and one for the main channel. They're nearly identical, with the same `ts`, etc.

However, the message event that is "sent" to the main channel is marked as "hidden" (and also has a `previous_message` property, but adding that to the models is non-trivial). To enable bots to only react to the original message in the thread (or vice versa?), I've add the "hidden" property to the model as well.

For reference:

<details><summary>Event for message in thread</summary>
<p>

```json
{
  "client_msg_id": "41d4e0ae-5ec9-4b59-b7c0-5b119cfab9b3",
  "type": "message",
  "subtype": "thread_broadcast",
  "event_ts": "1561118776.006600",
  "ts": "1561118776.006600",
  "text": "Test broadcast",
  "user": "UKT1ZAK39",
  "thread_ts": "1561118681.006500",
  "root": {
    "text": "Test",
    "user": "UKT1ZAK39",
    "ts": "1561118681.006500",
    "type": "message",
    "client_msg_id": "5e5b8b97-8b1a-4659-8414-61583501c872"
  },
  "user_team": "TKJRDK2BB",
  "source_team": "TKJRDK2BB",
  "channel": "CKTAKS9BQ"
}
```

</p>
</details>

<details><summary>Event for message relayed to channel</summary>
<p>

```json
{
  "client_msg_id": "41d4e0ae-5ec9-4b59-b7c0-5b119cfab9b3",
  "type": "message",
  "subtype": "thread_broadcast",
  "event_ts": "1561118777.006800",
  "ts": "1561118776.006600",
  "text": "Test broadcast",
  "user": "UKT1ZAK39",
  "thread_ts": "1561118681.006500",
  "root": {
    "reply_count": 1,
    "thread_ts": "1561118681.006500",
    "ts": "1561118681.006500",
    "reply_users": [
      "UKT1ZAK39"
    ],
    "reply_users_count": 1,
    "text": "Test",
    "replies": [
      {
        "user": "UKT1ZAK39",
        "ts": "1561118776.006600"
      }
    ],
    "client_msg_id": "5e5b8b97-8b1a-4659-8414-61583501c872",
    "type": "message",
    "latest_reply": "1561118776.006600",
    "user": "UKT1ZAK39"
  },
  "hidden": true,
  "message": {
    "root": {
      "reply_count": 1,
      "thread_ts": "1561118681.006500",
      "ts": "1561118681.006500",
      "reply_users": [
        "UKT1ZAK39"
      ],
      "reply_users_count": 1,
      "text": "Test",
      "replies": [
        {
          "user": "UKT1ZAK39",
          "ts": "1561118776.006600"
        }
      ],
      "client_msg_id": "5e5b8b97-8b1a-4659-8414-61583501c872",
      "type": "message",
      "latest_reply": "1561118776.006600",
      "user": "UKT1ZAK39"
    },
    "thread_ts": "1561118681.006500",
    "ts": "1561118776.006600",
    "subtype": "thread_broadcast",
    "text": "Test broadcast",
    "type": "message",
    "client_msg_id": "41d4e0ae-5ec9-4b59-b7c0-5b119cfab9b3",
    "user": "UKT1ZAK39"
  },
  "channel": "CKTAKS9BQ",
  "previous_message": {
    "root": {
      "reply_count": 1,
      "thread_ts": "1561118681.006500",
      "ts": "1561118681.006500",
      "reply_users": [
        "UKT1ZAK39"
      ],
      "reply_users_count": 1,
      "text": "Test",
      "replies": [
        {
          "user": "UKT1ZAK39",
          "ts": "1561118776.006600"
        }
      ],
      "client_msg_id": "5e5b8b97-8b1a-4659-8414-61583501c872",
      "type": "message",
      "latest_reply": "1561118776.006600",
      "user": "UKT1ZAK39"
    },
    "thread_ts": "1561118681.006500",
    "ts": "1561118776.006600",
    "subtype": "thread_broadcast",
    "text": "Test broadcast",
    "type": "message",
    "client_msg_id": "41d4e0ae-5ec9-4b59-b7c0-5b119cfab9b3",
    "user": "UKT1ZAK39"
  },
}
```

</p>
</details>